### PR TITLE
fix the ProtocolType order & adjust the cwl draft version 2

### DIFF
--- a/rabix-bindings/src/main/java/org/rabix/bindings/ProtocolType.java
+++ b/rabix-bindings/src/main/java/org/rabix/bindings/ProtocolType.java
@@ -2,9 +2,9 @@ package org.rabix.bindings;
 
 
 public enum ProtocolType {
-  CWL("org.rabix.bindings.cwl.CWLBindings", 3, "v1.0"),
-  DRAFT2("org.rabix.bindings.draft2.Draft2Bindings", 4, null),
-  SB("org.rabix.bindings.sb.SBBindings", 1, "sbg:draft-2"),
+  CWL("org.rabix.bindings.cwl.CWLBindings", 1, "v1.0"),
+  DRAFT2("org.rabix.bindings.draft2.Draft2Bindings", 3, "cwl:draft-2"),
+  SB("org.rabix.bindings.sb.SBBindings", 4, "sbg:draft-2"),
   DRAFT3("org.rabix.bindings.draft3.Draft3Bindings", 2, "cwl:draft-3");
 
   public final int order;


### PR DESCRIPTION
  1. 调整了解析协议的优先级顺序为cwlv1.0—>cwl:draft-3—>cwl:draft-2—>sbg:draft-2
  2. 把原项目中测试时未指定的cwl:draft-2的版本号补上